### PR TITLE
Add Requirements.txt, correct project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ the same serial command scheme.
 
 Currently supports retrieving status and writing to any relay on the device.
 
+** Supports Python versions between 2.7.x and 3.4 **
+(Due to use of the `enum34` library)
+
 Example Use:
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+enum34==1.1.6
+nose==1.3.6
+nose-cov==1.6
+pyserial>=3.0.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 setup(
-        name='Numato Controller',
+        name='numatocontroller',
         version='1.0.0',
         description='Wrapper for Numato USB Control Boards',
         author='Angaza',


### PR DESCRIPTION
* Add `requirements.txt` indicating the serial and nose libraries
* Remove a space from the project name
* Note supported Python versions in the README