### PR TITLE
Setup.py: Use setuptools, so a wheel can be made

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
-from distutils.core import setup
+from setuptools import setup
+
 setup(
-        name='numatocontroller',
-        version='1.0.0',
-        description='Wrapper for Numato USB Control Boards',
-        author='Angaza',
-        author_email='devices@angaza.com',
-        url='http://github.com/angaza/numato_control',
-        packages=['numato']
-        )
+    name='numatocontroller',
+    version='1.0.0',
+    description='Wrapper for Numato USB Control Boards',
+    author='Angaza',
+    author_email='devices@angaza.com',
+    url='http://github.com/angaza/numato_control',
+    packages=['numato']
+    )


### PR DESCRIPTION
Setuptools is required in order to generate a 'wheel'.