### PR TITLE
A few tweaks and added GPIO and analog input functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently supports retrieving status and writing to any relay on the device.
 **Supports Python versions between 2.7.x and 3.4**
 (Due to use of the `enum34` library)
 
+Later versions of Python should work with the built in enums.
+
 Example Use:
 
 ```
@@ -24,9 +26,20 @@ device.get_relay_state(0)  # Retrieve state of relay index 0
 <RelayState.RELAY_OFF: (0, 'off')>
 
 device.turn_on_relay(0)  # Turn on relay index 0
+device.write_relay_state(relay_index=1, new_state=0)  # Turning off relay index 1
 
 device.get_relay_state(0)
 <RelayState.RELAY_ON: (1, 'on')>
+
+device.write_gpio_state(gpio_index=0, new_state=1) # Setting (high) GPIO index 0
+device.write_gpio_state(gpio_index=1, new_state=0) # Clearing (low) GPIO index 1
+
+device.get_gpio_state(gpio_index=1)
+<GPIOState.GPIO_LOW: (0, 'clear')>
+
+device.read_adc(gpio_index=0)
+1023
+
 ```
 
 To execute the tests, from the repository root, use `nosetests`:

--- a/numato/numato_controller.py
+++ b/numato/numato_controller.py
@@ -191,7 +191,7 @@ class numato_controller(object):
 
         if isinstance(new_state, str):
             new_state = new_state.upper()
-            if new_state in ["ON", "TRUE"]:
+            if new_state in ["ON", "TRUE", "HIGH"]:
                 new_state = GPIOState.GPIO_HIGH
             else:
                 new_state = GPIOState.GPIO_LOW

--- a/numato/numato_controller.py
+++ b/numato/numato_controller.py
@@ -95,7 +95,7 @@ class numato_controller(object):
     def get_board_version(self):
         self.clear_and_reset_serial_port()
         self.relay_serial.write("\rver\r".encode())
-        response = self.relay_serial.read_until(terminator=">")
+        response = self.relay_serial.read_until(terminator=b">")
 
         # Parse the on/off string from the response
         parsed = response[5:].partition('\n\r')[0]
@@ -134,7 +134,7 @@ class numato_controller(object):
 
         self.clear_and_reset_serial_port()
         self.relay_serial.write(
-            "\rrelay {} {}\r".format(new_state.text, relay_index).encode())
+            "relay {} {}\r".format(new_state.text, relay_index).encode())
 
     def turn_on_relay(self, relay_index):
         """ Convenience function to turn on a relay index.
@@ -167,8 +167,8 @@ class numato_controller(object):
 
         self.clear_and_reset_serial_port()
         self.relay_serial.write(
-            "\rrelay read {}\r".format(relay_index).encode())
-        response = self.relay_serial.read_until(terminator=">")
+            "relay read {}\r".format(relay_index).encode())
+        response = self.relay_serial.read_until(terminator=b">")
 
         if b"off" in response:
             return RelayState.RELAY_OFF
@@ -210,7 +210,7 @@ class numato_controller(object):
 
         self.clear_and_reset_serial_port()
         self.relay_serial.write(
-            "\rgpio {} {}\r".format(new_state.text, gpio_index).encode())
+            "gpio {} {}\r".format(new_state.text, gpio_index).encode())
 
     def get_gpio_state(self, gpio_index):
         """ Read and return the state of the relay (on or off)
@@ -225,8 +225,8 @@ class numato_controller(object):
 
         self.clear_and_reset_serial_port()
         self.relay_serial.write(
-            "\rgpio read {}\r".format(gpio_index).encode())
-        response = self.relay_serial.read_until(terminator=">")
+            "gpio read {}\r".format(gpio_index).encode())
+        response = self.relay_serial.read_until(terminator=b">")
 
         # Trying to handle both combinations of \n\r and \r\n in case different products aren't consistent
         if b"\r0\n" in response or b"\n0\r" in response:
@@ -249,14 +249,15 @@ class numato_controller(object):
 
         self.clear_and_reset_serial_port()
         self.relay_serial.write(
-            "\radc read {}\r".format(gpio_index).encode())
-        response = self.relay_serial.read_until(terminator=">")
+            "adc read {}\r".format(gpio_index).encode())
+        response = self.relay_serial.read_until(terminator=b">")
 
         try:
             response.decode('utf-8')
-            response = response.split(sep=b"\n")
+            response = response.split(b"\n")
             return int(response[-2])
-        except:
+        except Exception as e:
+            print(e)
             return -1
 
     def __exit__(self, type, value, traceback):

--- a/numato/numato_controller.py
+++ b/numato/numato_controller.py
@@ -90,7 +90,7 @@ class numato_controller(object):
         self.relay_serial.reset_output_buffer()
         self.relay_serial.reset_input_buffer()
         self.relay_serial.write("\r".encode())
-        self.relay_serial.read_until(terminator=">")
+        self.relay_serial.read_until(terminator=b">")
 
     def get_board_version(self):
         self.clear_and_reset_serial_port()


### PR DESCRIPTION
- Changing the serial reads to read_until(b">") to avoid waiting longer than is necessary
- Changed the clear_and_reset_serial_port method to clear buffers and then send a return and read until the next prompt; rather than waiting a second.
- Extended the write_relay_state to accept a string, boolean or int/float to turn the relays on or off, needing to use the enum's seemed a bit cumbersome.
- Changed the get_relay_state to look for a substring and not at specific characters locations - hopefully this will be a more robust implementation
- Adding a GPIOState enum
- Added write_gpio_state, get_gpio_state and read_adc in a similar manner to the rest of the methods.